### PR TITLE
fix syntax typo

### DIFF
--- a/src/pages/hooks.js
+++ b/src/pages/hooks.js
@@ -51,13 +51,11 @@ import { useAnimateGroup } from 'react-simple-animate';
 
 export default function example {
   const [{styles, play}, startAnimation] = useAnimateGroup({
-    sequences: {
-      {
-        startStyle: { opacity: 0 }, // refer <Animate /> for props information
-        endStyle: { opacity: 1 }
-      },
+    sequences: [{
+      startStyle: { opacity: 0 }, // refer <Animate /> for props information
+      endStyle: { opacity: 1 },
       keyframes: [ 'opacity: 0', 'opacity: 1' ], // refer <AniamteKeyframes /> for props information
-    }
+    }]
   });
   
   return <>


### PR DESCRIPTION
Hope I've got the syntax correct. The existing code isn't syntactically valid so it has to be something different. This is based on looking at the code (it looks like keyframes is expected to be a child property of sequences items)