### PR TITLE
fix typo: Animate completion style is "complete"

### DIFF
--- a/src/components/props/animateData.js
+++ b/src/components/props/animateData.js
@@ -48,7 +48,7 @@ export default [
     name: (
       <>
         {' '}
-        onComplete: <PropType>Object</PropType>
+        complete: <PropType>Object</PropType>
       </>
     ),
     description: (


### PR DESCRIPTION
This is according to the example and what I understand from the source, I haven't actually tested this, just noticed from reading the docs.